### PR TITLE
Working on usershub-auth-module genericity

### DIFF
--- a/src/pypnusershub/db/tools.py
+++ b/src/pypnusershub/db/tools.py
@@ -6,9 +6,31 @@ from __future__ import (unicode_literals, print_function,
     DB tools not related to any model in particular.
 """
 
+from flask import current_app
+
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import create_engine
 
+from itsdangerous import (TimedJSONWebSignatureSerializer as Serializer,
+                          SignatureExpired, BadSignature)
+
+from pypnusershub.db import models
 from pypnusershub.utils import text_resource_stream
+
+class AccessRightsError(Exception):
+    pass
+
+
+class InsufficientRightsError(AccessRightsError):
+    pass
+
+
+class AccessRightsExpiredError(AccessRightsError):
+    pass
+
+
+class UnreadableAccessRightsError(AccessRightsError):
+    pass
 
 
 def init_schema(con_uri):
@@ -44,3 +66,32 @@ def load_fixtures(con_uri):
                 if line.strip():
                     engine.execute(line)
             engine.execute("COMMIT")
+
+
+def user_from_token(token, secret_key=None):
+    """Given a, authentification token, return the matching AppUser instance"""
+
+    secret_key = secret_key or current_app.config['SECRET_KEY']
+
+    try:
+        s = Serializer(current_app.config['SECRET_KEY'])
+        data = s.loads(token)
+
+        id_role = data['id_role']
+        id_app = data['id_application']
+        return (models.AppUser
+                      .query
+                      .filter(models.AppUser.id_role == id_role)
+                      .filter(models.AppUser.id_application == id_app)
+                      .one())
+
+    except NoResultFound:
+        return UnreadableAccessRightsError(
+            'No user withd id "{}" for app "{}"'.format(id_role, id_app)
+        )
+    except SignatureExpired:
+        raise AccessRightsExpiredError("Token expired")
+
+    except BadSignature:
+        return UnreadableAccessRightsError('Token BadSignature', 403)
+

--- a/src/pypnusershub/utils.py
+++ b/src/pypnusershub/utils.py
@@ -20,6 +20,7 @@ class RessourceError(EnvironmentError):
         self.errors = errors
 
 
+
 def binary_resource_stream(resource, locations):
     """ Return a resource from this path or package """
 
@@ -66,3 +67,4 @@ def text_resource_stream(path, locations, encoding="utf8", errors=None,
     """ Return a resource from this path or package. Transparently decode the stream. """
     stream = binary_resource_stream(path, locations)
     return io.TextIOWrapper(stream, encoding, errors, newline, line_buffering)
+


### PR DESCRIPTION
Bonjour,

Pour le projet du Mercantour j'avais besoin de certaines fonctionalités:

- logout
- redirections sur un token expiré

En développant celles-ci, j'ai aussi noté:

- que les mots de passe de usershub étaient hashés en md5
- que les tables liées aux droits étaient nécessaires pour certaines opérations 
- j'avais introduit une régression dans ma dernière PR
- on charge le modèle user plusieurs fois après le login 
- la gestion des exceptions et codes de retour a besoin d'un peu de nettoyage
- le cookie de session est renouvelé dans certains contextes où on ne le souhaite pas
- les modèles n'ont pas de `__repr__`
- AppUser affiche une vue en lecture seule et on ne peut donc pas setter le password 

Voici donc une PR qui vise ces problématiques. Points clés :

Models: 
- nouvelles classes pour mapper les tables bib_droits et cor_role_droit_application
- la classe User utilise md5 pour hasher son password au lieu de sha256. Il faudrait alerter UsersHub de changer le hashing de leur password pour un algo plus robuste et avec un salt. Mais en attendant on doit utiliser le leur. 
 - `__repr__` pour faciliter le debuggage
 -  AppUser n'a plus de setter sur le password puisque c'est une vue en lecture seule

Auth workflow:

- exceptions plus granulaires et exceptions personnalisées
- obtenir un objet User depuis un token est maintenant une fonction indépendante 
- ajout d'une vue pour le log out
- pas de renouvellement de cookie si le token est vide ou en cours d'écriture
- redirection optionnelle sur check_auth
- usage optionnel des codes HTTP standards pour les erreurs 
- le modèle user est maintenant attaché à Flask.g
- COOKIE_AUTORENEW passe sur True par défaut pour éviter d'avoir à setter la valeur pour les projets existant. Une erreur de ma part dans la première PR.

