### PR TITLE
Fix setup.py open() encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ from __future__ import ( print_function,
 import re
 import setuptools
 
+from codecs import open
+
 def get_version(path="src/pypnusershub/__init__.py"):
     """ Return the version of by with regex intead of importing it"""
     init_content = open(path, "rt").read()
@@ -18,7 +20,7 @@ setuptools.setup(
     name='pypnusershub',
     version=get_version(),
     description="Python lib to authenticate using PN's UsersHub",
-    long_description=open('README.md').read().strip(),
+    long_description=open('README.md', encoding="utf8").read().strip(),
     author="Les parcs nationaux de France",
     url='https://github.com/PnX-SI/UsersHub-authentification-module',
     packages=setuptools.find_packages('src'),

--- a/src/pypnusershub/db/fixtures.sql
+++ b/src/pypnusershub/db/fixtures.sql
@@ -28,15 +28,4 @@ INSERT INTO utilisateurs.t_applications (id_application, nom_application, desc_a
 INSERT INTO utilisateurs.t_applications (id_application, nom_application, desc_application) VALUES (2, 'Taxhub', 'application permettant d''administrer la liste des taxons.');
 INSERT INTO utilisateurs.t_applications (id_application, nom_application, desc_application) VALUES (14, 'application GeoNature', 'Application permettant la consultation et la gestion des relevés faune et flore.');
 
-INSERT INTO utilisateurs.t_roles (groupe, id_role, identifiant, nom_role, prenom_role, desc_role, pass, email, organisme, id_unite, pn, session_appli, date_insert, date_update, id_organisme, remarques) VALUES (true, 20002, NULL, 'grp_en_poste', NULL, 'Tous les agents en poste', NULL, NULL, 'monpn', 99, true, NULL, NULL, NULL, NULL,'groupe test');
-INSERT INTO utilisateurs.t_roles (groupe, id_role, identifiant, nom_role, prenom_role, desc_role, pass, email, organisme, id_unite, pn, session_appli, date_insert, date_update, id_organisme, remarques) VALUES (false, 1, 'admin', 'Administrateur', 'test', NULL, '21232f297a57a5a743894a0e4a801fc3', '', 'Parc national des Ecrins', 1, true, NULL, NULL, NULL, 99,'utilisateur test à modifier ou supprimer');
-INSERT INTO utilisateurs.t_roles (groupe, id_role, identifiant, nom_role, prenom_role, desc_role, pass, email, organisme, id_unite, pn, session_appli, date_insert, date_update, id_organisme, remarques) VALUES (false, 3, 'partenaire', 'Partenaire', 'test', NULL, '5bd40a8524882d75f3083903f2c912fc', '', 'Autre', 99, true, NULL, NULL, NULL, 99,'utilisateur test à modifier ou supprimer');
-INSERT INTO utilisateurs.t_roles (groupe, id_role, identifiant, nom_role, prenom_role, desc_role, pass, email, organisme, id_unite, pn, session_appli, date_insert, date_update, id_organisme, remarques) VALUES (false, 2, 'agent', 'Agent', 'test', NULL, 'b33aed8f3134996703dc39f9a7c95783', '', 'Parc national des Ecrins', 1, true, NULL, NULL, NULL, 99,'utilisateur test à modifier ou supprimer');
-
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (1, 6, 1);
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (1, 6, 2);
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (1, 6, 14);
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (20002, 3, 14);
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (2, 2, 14);
-INSERT INTO utilisateurs.cor_role_droit_application (id_role, id_droit, id_application) VALUES (3, 1, 14);
 

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -84,7 +84,7 @@ class User(db.Model):
         return "<User '{!r}' id='{}'>".format(self.identifiant, self.id_role)
 
     def __str__(self):
-        return self.identifiant
+        return self.identifiant or ''
 
 
 class Application(db.Model):

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -11,17 +11,26 @@ import hashlib
 
 from flask_sqlalchemy import SQLAlchemy
 
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, Sequence
 
 db = SQLAlchemy()
+
 
 
 class User(db.Model):
 
     __tablename__ = 't_roles'
     __table_args__ = {'schema': 'utilisateurs'}
+
+    TABLE_ID = Sequence('t_roles_id_seq', start=1000)
+
     groupe = db.Column(db.Boolean)
-    id_role = db.Column(db.Integer, primary_key=True)
+    id_role = db.Column(
+        db.Integer,
+        TABLE_ID,
+        primary_key=True,
+        server_default=TABLE_ID.next_value()
+    )
     # TODO: make that unique ?
     identifiant = db.Column(db.Unicode)
     nom_role = db.Column(db.Unicode)

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -11,10 +11,10 @@ import hashlib
 
 from flask_sqlalchemy import SQLAlchemy
 
-from sqlalchemy.orm import relationship, Sequence
+from sqlalchemy.orm import relationship
+from sqlalchemy import Sequence
 
 db = SQLAlchemy()
-
 
 
 class User(db.Model):
@@ -22,14 +22,16 @@ class User(db.Model):
     __tablename__ = 't_roles'
     __table_args__ = {'schema': 'utilisateurs'}
 
-    TABLE_ID = Sequence('t_roles_id_seq', start=1000)
+    TABLE_ID = Sequence(
+        't_roles_id_seq',
+        schema="utilisateurs",
+    )
 
     groupe = db.Column(db.Boolean)
     id_role = db.Column(
         db.Integer,
         TABLE_ID,
         primary_key=True,
-        server_default=TABLE_ID.next_value()
     )
     # TODO: make that unique ?
     identifiant = db.Column(db.Unicode)


### PR DESCRIPTION
Cette PR rajoute une gestion explicite de l'encoding du README dans le fichier setup.py. 

On peut ainsi maintenant installer UsersHub-authentification-module avec pip:

    pip install git+https://github.com/PnX-SI/UsersHub-authentification-module/

Et même l'ajouter dans un fichier requirements.txt.
