### PR TITLE
add unique constraint on email_role

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 *********
 
+1.6.6 (2023-??-??)
+------------------
+
+**🚀 Nouveautés**
+
+* Ajout d’une contrainte d’unicité sur la colonne ``email`` de la table ``t_roles``.
+
 1.6.5 (2023-03-04)
 ------------------
 
@@ -52,7 +59,7 @@ CHANGELOG
 
 **🚀 Nouveautés**
 
-* Ajout d’une contrainte d’unicité sur la colonn ``uuid_role`` de la table ``t_roles``.
+* Ajout d’une contrainte d’unicité sur la colonne ``uuid_role`` de la table ``t_roles``.
 * Ajout des modèles ``UserList`` et ``cor_role_liste`` correspondants aux tables existantes.
 * Compatibilité Flask 2
 

--- a/src/pypnusershub/migrations/versions/36998af706d1_add_unique_constraint_on_email_role.py
+++ b/src/pypnusershub/migrations/versions/36998af706d1_add_unique_constraint_on_email_role.py
@@ -1,0 +1,32 @@
+"""add unique constraint on email_role
+
+Revision ID: 36998af706d1
+Revises: 112ccf1024ce
+Create Date: 2023-03-09 11:18:14.006181
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '36998af706d1'
+down_revision = '112ccf1024ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(
+        constraint_name="t_roles_email_un",
+        table_name="t_roles",
+        columns=["email"],
+        schema="utilisateurs"
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        constraint_name="t_roles_email_un",
+        table_name="t_roles",
+        schema="utilisateurs"
+        )


### PR DESCRIPTION
Ajout d'une contrainte d'unicité sur le champ email de la table `utilisateurs.t_roles` comme évoqué sur cette issue de UsersHub (https://github.com/PnX-SI/UsersHub/issues/122)

fix https://github.com/PnX-SI/UsersHub/issues/122