### PR TITLE
Add property max_level_profil to default exclude columns

### DIFF
--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -133,7 +133,6 @@ class User(db.Model, UserMixin):
     active = db.Column(db.Boolean)
     groups = db.relationship(
         "User",
-        lazy="joined",
         secondary=cor_roles,
         primaryjoin="User.id_role == utilisateurs.cor_roles.c.id_role_utilisateur",
         secondaryjoin="User.id_role == utilisateurs.cor_roles.c.id_role_groupe",

--- a/src/pypnusershub/schemas.py
+++ b/src/pypnusershub/schemas.py
@@ -12,7 +12,7 @@ class UserSchema(SmartRelationshipsMixin, ma.SQLAlchemyAutoSchema):
         include_fk = True
         load_instance = True
         sqla_session = db.session
-        exclude = ("_password", "_password_plus", "champs_addi")
+        exclude = ("_password", "_password_plus", "champs_addi", "max_level_profil")
 
     max_level_profil = fields.Integer()
     nom_complet = fields.String()

--- a/src/pypnusershub/tests/test_utils.py
+++ b/src/pypnusershub/tests/test_utils.py
@@ -6,8 +6,6 @@ from werkzeug.http import parse_cookie
 
 from pypnusershub.utils import get_cookie_path, set_cookie, delete_cookie
 
-from .utils import set_logged_user_cookie
-
 
 class TestUtils:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Add property max_level_profil to default exclude columns of marshmallow schema-> it make raise a raiseload error on some module