### PR TITLE
fix: adujst imports from .xxx to pypnusershub.xxx

### DIFF
--- a/src/pypnusershub/routes_register.py
+++ b/src/pypnusershub/routes_register.py
@@ -26,8 +26,8 @@ from flask import (
 
 from functools import wraps
 
-from .db.models import Application, UserApplicationRight, AppUser, db
-from .env import REGISTER_POST_ACTION_FCT
+from pypnusershub.db.models import Application, UserApplicationRight, AppUser, db
+from pypnusershub.env import REGISTER_POST_ACTION_FCT
 
 from flask import current_app
 from sqlalchemy import select


### PR DESCRIPTION
On préfère ici utiliser le chemin d'import pypnusershub.XXX au lieu de .XXX

Le chemin introduit des confusions de chemins, par exemple lors de l'utilisation d'un debugger au niveau de l'appli GeoNature.
