### PR TITLE
feat: add auto_validate_new_user boolean field

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,16 @@ Les routes déclarées par le _blueprint_ de `UsersHub-authentification-module` 
 
 Les routes suivantes sont implémentés dans `UsersHub-authentification-module`:
 
-| Route URI           | Action                                                                                                                                       | Paramètres                 | Retourne                         |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------- |
-| `/providers`        | Retourne l'ensemble des fournisseurs d'identité activés                                                                                      | NA                         |                                  |
-| `/get_current_user` | Retourne les informations de l'utilisateur connecté                                                                                          | NA                         | {user,expires,token}             |
-| `/login/<provider>` | Connecte un utilisateur avec le provider <provider>                                                                                          | Optionnel({user,password}) | {user,expires,token} ou redirect |
-| `/public_login`     | Connecte l'utilisateur permettant l'accès public à votre application                                                                         | NA                         | {user,expires,token}             |
-| `/logout`           | Déconnecte l'utilisateur courant                                                                                                             | NA                         | redirect                         |
-| `/authorize`        | Connecte un utilisateur à l'aide des infos retournées par le fournisseur d'identité (Si redirection vers un portail de connexion par /login) | {data}                     | redirect                         |
+| Route URI           | Action                                                                                                                                         | Paramètres                 | Retourne                         |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------- |
+| `/providers`        | Retourne l'ensemble des fournisseurs d'identités activés                                                                                       | NA                         |                                  |
+| `/get_current_user` | Retourne les informations de l'utilisateur connecté                                                                                            | NA                         | {user,expires,token}             |
+| `/login/<provider>` | Connecte un utilisateur avec le provider <provider>                                                                                            | Optionnel({user,password}) | {user,expires,token} ou redirect |
+| `/public_login`     | Connecte l'utilisateur permettant l'accès public à votre application                                                                           | NA                         | {user,expires,token}             |
+| `/logout`           | Déconnecte l'utilisateur courant                                                                                                               | NA                         | redirect                         |
+| `/authorize`        | Connecte un utilisateur à l'aide des infos retournées par le fournisseurs d'identités (Si redirection vers un portail de connexion par /login) | {data}                     | redirect                         |
+
+En cas d'erreur d'autorisation, la route `/authorize` redirige vers la page de login avec un paramètre `login_error` (message destiné au frontend).
 
 ### Méthodes définies dans le module
 

--- a/src/pypnusershub/auth/providers/openid_provider.py
+++ b/src/pypnusershub/auth/providers/openid_provider.py
@@ -72,26 +72,17 @@ class OpenIDProvider(Authentication):
             else []
         )
 
-        # Auto-validation: create/update user and allow login immediately
-        if self.auto_validate_new_user:
-            user = self.insert_or_update_role(
-                new_user,
-                source_groups=source_groups,
-                reconciliate_attr=self.reconciliate_attr,
-                fields_to_update=self.fields_to_override,
-            )
-            db.session.commit()
-            return user
-
-        # Manual validation: existing users can still log in
-        user = db.session.execute(
+        # Existing user
+        existing_user = db.session.execute(
             sa.select(models.User).where(
                 getattr(models.User, self.reconciliate_attr)
                 == new_user[self.reconciliate_attr]
             )
         ).scalar_one_or_none()
 
-        if user:
+        # Manual validation: existing users can still log in
+        # Auto-validation: create/update user and allow login immediately
+        if existing_user or self.auto_validate_new_user:
             user = self.insert_or_update_role(
                 new_user,
                 source_groups=source_groups,

--- a/src/pypnusershub/auth/providers/openid_provider.py
+++ b/src/pypnusershub/auth/providers/openid_provider.py
@@ -1,10 +1,14 @@
+from datetime import datetime
 from typing import Any, Optional, Tuple, Union
 
 import requests
 from flask import Response, current_app, session, url_for
+import sqlalchemy as sa
 from marshmallow import EXCLUDE, ValidationError, fields
 from pypnusershub.auth import Authentication, ProviderConfigurationSchema, oauth
+from pypnusershub.auth.user_manager import UserManager
 from pypnusershub.db import db, models
+from pypnusershub.utils import get_current_app_id
 from werkzeug.exceptions import Unauthorized
 from enum import Enum
 
@@ -38,6 +42,7 @@ class OpenIDProvider(Authentication):
     group_claim_name = "groups"
     identifier_field = "preferred_username"
     reconciliate_attr = "email"
+    auto_validate_new_user = True
 
     def authenticate(self, *args, **kwargs) -> Union[Response, models.User]:
         redirect_uri = url_for(
@@ -59,21 +64,72 @@ class OpenIDProvider(Authentication):
             UserColumns.EMAIL: user_info["email"],
             UserColumns.PRENOM_ROLE: user_info["given_name"],
             UserColumns.NOM_ROLE: user_info["family_name"],
-            UserColumns.ACTIVE: True,
+            UserColumns.ACTIVE: self.auto_validate_new_user,
         }
         source_groups = (
             user_info[self.group_claim_name]
             if self.group_claim_name in user_info
             else []
         )
-        user = self.insert_or_update_role(
-            new_user,
-            source_groups=source_groups,
-            reconciliate_attr=self.reconciliate_attr,
-            fields_to_update=self.fields_to_override,
+
+        # Auto-validation: create/update user and allow login immediately
+        if self.auto_validate_new_user:
+            user = self.insert_or_update_role(
+                new_user,
+                source_groups=source_groups,
+                reconciliate_attr=self.reconciliate_attr,
+                fields_to_update=self.fields_to_override,
+            )
+            db.session.commit()
+            return user
+
+        # Manual validation: existing users can still log in
+        user = db.session.execute(
+            sa.select(models.User).where(
+                getattr(models.User, self.reconciliate_attr)
+                == new_user[self.reconciliate_attr]
+            )
+        ).scalar_one_or_none()
+
+        if user:
+            user = self.insert_or_update_role(
+                new_user,
+                source_groups=source_groups,
+                reconciliate_attr=self.reconciliate_attr,
+                fields_to_update=self.fields_to_override,
+            )
+            db.session.commit()
+            return user
+
+        # Manual validation: new users create a temp request
+        # - Avoid creating duplicate pending requests
+        temp_user_exists = db.session.execute(
+            sa.select(models.TempUser).where(
+                getattr(models.TempUser, self.reconciliate_attr)
+                == new_user[self.reconciliate_attr],
+            )
+        ).scalar_one_or_none()
+
+        if temp_user_exists:
+            raise Unauthorized(
+                "Demande de creation de compte en attente de validation."
+            )
+
+        # - create pending request
+        temp_user = models.TempUser(
+            token_role=UserManager.generate_token(),
+            identifiant=new_user["identifiant"],
+            nom_role=new_user["nom_role"],
+            prenom_role=new_user["prenom_role"],
+            email=new_user["email"],
+            groupe=False,
+            id_application=get_current_app_id(),
         )
+        db.session.add(temp_user)
         db.session.commit()
-        return user
+        raise Unauthorized(
+            "Demande de creation de compte créée et en attente de validation."
+        )
 
     def revoke(self):
         if not "openid_token_resp" in session:
@@ -99,6 +155,7 @@ class OpenIDProvider(Authentication):
                 load_default="preferred_username"
             )  # Claim d’identification du token OpenID/OIDC
             RECONCILIATE_ATTR = fields.String(load_default="email")
+            AUTO_VALIDATE_NEW_USER = fields.Boolean(load_default=False)
             CODE_CHALLENGE_METHOD = fields.String(
                 load_default="S256",
                 validate=fields.validate.OneOf(["plain", "S256"]),
@@ -137,6 +194,7 @@ class OpenIDProvider(Authentication):
         self.identifier_field = configuration["IDENTIFIER_FIELD"]
         self.reconciliate_attr = configuration["RECONCILIATE_ATTR"]
         self.fields_to_override = configuration["FIELDS_TO_OVERRIDE"]
+        self.auto_validate_new_user = configuration["AUTO_VALIDATE_NEW_USER"]
 
 
 class OpenIDConnectProvider(OpenIDProvider):

--- a/src/pypnusershub/routes.py
+++ b/src/pypnusershub/routes.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import logging
 from typing import List
-from urllib.parse import urljoin
+from urllib.parse import urlencode, urljoin
 
 import sqlalchemy as sa
 from flask import (
@@ -216,7 +216,17 @@ def logout():
 @routes.route("/authorize/<provider>", methods=["GET", "POST"])
 def authorize(provider="local_provider"):
     auth_provider = current_app.auth_manager.get_provider(provider)
-    authorize_result = auth_provider.authorize()
+    try:
+        authorize_result = auth_provider.authorize()
+    except (Unauthorized, Forbidden) as exc:
+        log.exception("Authorization error for provider %s", provider)
+        error_description = exc.description or "Unauthorized"
+        login_url = f"{current_app.config['URL_APPLICATION']}/#/login"
+        query_params = {
+            "login_error": error_description,
+        }
+        return redirect(f"{login_url}?{urlencode(query_params)}", code=302)
+
     if isinstance(authorize_result, models.User):
         login_user(authorize_result, remember=True)
 


### PR DESCRIPTION
Closes #142 

Ajout de l'entrée de config "auto_validate_new_user", vraie par défaut. 

L'appel à insert_or_update_role dans authorize a été étoffé.

Si `auto_validate_new_user` est à vrai --> comportement actuel. 
Sinon: 
  - si l'utilisateur a déjà fait une demande de compte `raise Unauthorized("Demande de creation de compte en attente de validation.")`
  - si c'est une nouvelle demande:
    1) Création de la demande
    2) `raise Unauthorized("Demande de creation de compte créée et en attente de validation.")`