### PR TITLE
Feat: ajout d'un paramètre `is_secondary` aux fournisseurs d'identité

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,15 +236,14 @@ Les routes déclarées par le _blueprint_ de `UsersHub-authentification-module` 
 
 Les routes suivantes sont implémentés dans `UsersHub-authentification-module`:
 
-| Route URI           | Action                                                                                                                                         | Paramètres                 | Retourne                         |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------- |
-| `/providers`        | Retourne l'ensemble des fournisseurs d'identités activés                                                                                       | NA                         |                                  |
-| `/get_current_user` | Retourne les informations de l'utilisateur connecté                                                                                            | NA                         | {user,expires,token}             |
-| `/login/<provider>` | Connecte un utilisateur avec le provider <provider>                                                                                            | Optionnel({user,password}) | {user,expires,token} ou redirect |
-| `/public_login`     | Connecte l'utilisateur permettant l'accès public à votre application                                                                           | NA                         | {user,expires,token}             |
-| `/logout`           | Déconnecte l'utilisateur courant                                                                                                               | NA                         | redirect                         |
-| `/authorize`        | Connecte un utilisateur à l'aide des infos retournées par le fournisseurs d'identités (Si redirection vers un portail de connexion par /login) | {data}                     | redirect                         |
-
+| Route URI           | Action                                                                                                                                       | Paramètres                 | Retourne                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | -------------------------------- |
+| `/providers`        | Retourne l'ensemble des fournisseurs d'identité activés                                                                                      | NA                         |                                  |
+| `/get_current_user` | Retourne les informations de l'utilisateur connecté                                                                                          | NA                         | {user,expires,token}             |
+| `/login/<provider>` | Connecte un utilisateur avec le provider <provider>                                                                                          | Optionnel({user,password}) | {user,expires,token} ou redirect |
+| `/public_login`     | Connecte l'utilisateur permettant l'accès public à votre application                                                                         | NA                         | {user,expires,token}             |
+| `/logout`           | Déconnecte l'utilisateur courant                                                                                                             | NA                         | redirect                         |
+| `/authorize`        | Connecte un utilisateur à l'aide des infos retournées par le fournisseur d'identité (Si redirection vers un portail de connexion par /login) | {data}                     | redirect                         |
 
 ### Méthodes définies dans le module
 
@@ -260,13 +259,13 @@ Par défaut, les routes sont accessibles depuis le préfixe `/auth/`. Si vous vo
 auth_manager.init_app(app, prefix="/authentification", providers_declaration=providers_config)
 ```
 
-## Connexion à l'aide de fournisseurs d'identités extérieurs
+## Connexion à l'aide de fournisseurs d'identité extérieurs
 
-Depuis la version 3.0, il est possible d'ajouter la possibilité de se connecter à des fournisseurs d'identités externes utilisant d'autres protocoles de connexion : OpenID, OpenID Connect, CAS (INPN), etc. ...
+Depuis la version 3.0, il est possible d'ajouter la possibilité de se connecter à des fournisseurs d'identité externes utilisant d'autres protocoles de connexion : OpenID, OpenID Connect, CAS (INPN), etc. ...
 
 ### Utiliser les protocoles de connexions existant
 
-Lors de l'appel de `AuthManager.init_app`, il faut indiquer les configurations des différents fournisseurs d'identités sur lesquels on souhaite se connecter dans le paramètre `providers_declaration`.
+Lors de l'appel de `AuthManager.init_app`, il faut indiquer les configurations des différents fournisseurs d'identité sur lesquels on souhaite se connecter dans le paramètre `providers_declaration`.
 
 Pour chaque configuration, on doit déclarer :
 
@@ -310,10 +309,10 @@ Pour lancer la connexion sur un provider en particulier, il suffit d'appeler la 
 
 **OpenID et OpenIDConnect**.
 
-- `group_claim_name` (string) : nom du champs retournée par le fournisseur d'identités dans lequel se trouve la liste de groupes auquel l'utilisateur appartient (par défaut : "groups").
-- `ISSUER` (string) : URL du fournisseur d'identités
-- `CLIENT_ID` (string) : Identifiant publique de l'application auprès du fournisseur d'identités.
-- `CLIENT_SECRET` (string) : Clé secrete connue uniquement par l'application et le fournisseur d'identités.
+- `group_claim_name` (string) : nom du champs retournée par le fournisseur d'identité dans lequel se trouve la liste de groupes auquel l'utilisateur appartient (par défaut : "groups").
+- `ISSUER` (string) : URL du fournisseur d'identité
+- `CLIENT_ID` (string) : Identifiant publique de l'application auprès du fournisseur d'identité.
+- `CLIENT_SECRET` (string) : Clé secrete connue uniquement par l'application et le fournisseur d'identité.
 
 **UsersHub-authentification-module**
 
@@ -355,7 +354,7 @@ class NEW_PROVIDER(Authentication):
         pass # if specific action have to be made when logout
 
     def configure(self, configuration: Union[dict, Any]):
-        pass # Indique la configuration d'un fournisseur d'identités
+        pass # Indique la configuration d'un fournisseur d'identité
 ```
 
 Un **protocole de connexion** est défini par 5 méthodes et plusieurs attributs.
@@ -365,13 +364,14 @@ Les attributs sont les suivants
 - L'attribut `id_provider` indique l'identifiant de l'instance du provider.
 - Les attributs `logo` et `label` sont destinés à l'interface utilisateur.
 - L'attribut `is_external` spécifie si le provider permet de se connecter à une autre application Flask utilisant `UsersHub-authentification-module` ou à un fournisseur d'identité qui requiert une redirection vers une page de login.
+- L'attribut `is_secondary` permet de définir des fournisseurs d'identité secondaires, qui seront placés sous le ou les fournisseurs principaux, derrière un composant `details` sur la page de connexion.
 - L'attribut `login_url` et `logout_url`, si le protocole de connexion nécessite une redirection
-- L'attribut `group_mapping` contient le mapping entre les groupes du fournisseurs d'identités et celui de votre instance de GeoNature.
+- L'attribut `group_mapping` contient le mapping entre les groupes du fournisseurs d'identité et celui de votre instance de GeoNature.
 
 Les méthodes sont les suivantes :
 
 - `authenticate`: Lancée sur la route `/auth/login`, elle récupère les informations du formulaire de login et retourne un objet `User`. Si le protocole de connexion doit rediriger l'utilisateur vers un portail, alors authenticate retourne une `flask.Response` qui redirige vers ce dernier.
-- `authorize`: Cette méthode est lancée par la route `/auth/authorize` qui récupère les informations renvoyés par le fournisseur d'identités après la connexions sur le portail.
+- `authorize`: Cette méthode est lancée par la route `/auth/authorize` qui récupère les informations renvoyés par le fournisseur d'identité après la connexions sur le portail.
 - `configure(self, configuration: Union[dict, Any])`: Permet de récupérer et d'utiliser les variables présentes dans le fichier de configuration. Il est possible aussi de valider les résultats à l'aide d'un schéma `marshmallow`
 - `revoke()`: Permet de spécifier un fonctionnement spécifique lors de la déconnexion d'un utilisateur.
 
@@ -382,7 +382,7 @@ Les méthodes sont les suivantes :
 > #### Concepts essentiels
 >
 > **Profil**: Concept associé à un nom et à un niveau de permission.
-> **Provider**: Concept associé à celui de fournisseurs d'identités. Service (Google, INPN, ORCID,...) qui permet de s’identifier et qui utilise un protocole de connexion (e.g. _OAuth_)
+> **Provider**: Concept associé à celui de fournisseurs d'identité. Service (Google, INPN, ORCID,...) qui permet de s’identifier et qui utilise un protocole de connexion (e.g. _OAuth_)
 > **Listes**: Groupe d'utilisateurs
 
 ### Structure de la base
@@ -528,13 +528,13 @@ cor_profil_for_app *-- t_applications
 | bib_organismes      | Contient les organismes                                                                      |
 | t_roles             | Contient les utilisateurs                                                                    |
 | t_profils           | Permet de définir les profils de permissions                                                 |
-| t_providers         | Contient les fournisseurs d'identités dans l'applications                                    |
+| t_providers         | Contient les fournisseurs d'identité dans l'applications                                     |
 | t_applications      | Liste les applications qui utilisent UsersHub-authentification-module                        |
 | temp_users          | Permet de créer des utilisateurs temporaires (en attente de validation par l'administrateur) |
 | cor_profil_for_app  | Permet d'attribuer et limiter les profils disponibles pour chacune des applications          |
 | cor_role_app_profil | Cette table permet d'associer des utilisateurs à des profils par application                 |
 | cor_role_list       | Cette table permet d'associer des utilisateurs à des listes d'utilisateurs                   |
-| cor_role_provider   | Cette table permet d'associer des utilisateurs à des fournisseurs d'identités                |
+| cor_role_provider   | Cette table permet d'associer des utilisateurs à des fournisseurs d'identité                 |
 | cor_role_token      | Permet d'associer des utilisateurs à des tokens                                              |
 | cor_roles           | Permet d'associer des utilisateurs entre eux (groupes et utilisateurs)                       |
 

--- a/src/pypnusershub/auth/auth_manager.py
+++ b/src/pypnusershub/auth/auth_manager.py
@@ -18,6 +18,7 @@ ProviderType = TypedDict(
         "label": str,
         "group_mapping": dict,
         "logo": str,
+        "is_secondary": bool,
     },
 )
 
@@ -71,7 +72,7 @@ class AuthManager:
             raise AssertionError("Provider must be an instance of Authentication")
         if id_provider in self.provider_authentication_cls:
             raise Exception(
-                f"Id provider {id_provider} already exist, please check your authentication config"
+                f"Id provider {id_provider} already exists, please check your authentication config"
             )
         self.provider_authentication_cls[id_provider] = provider_authentification
 

--- a/src/pypnusershub/auth/authentication.py
+++ b/src/pypnusershub/auth/authentication.py
@@ -17,6 +17,7 @@ class ProviderConfigurationSchema(Schema):
     group_mapping = fields.Dict(keys=fields.Str(), values=fields.Integer())
     logo = fields.String()
     label = fields.String()
+    is_secondary = fields.Boolean()
 
     @validates_schema
     def check_if_module_exists(self, data, **kwargs):
@@ -81,6 +82,12 @@ class Authentication:
     URL or html of the logo image
     """
     logo = ""
+
+    """
+    Is the authentication provider secondary?  (boolean)
+    Will affect login page presentation
+    """
+    is_secondary = False
 
     @property
     def is_external(self) -> bool:
@@ -166,7 +173,14 @@ class Authentication:
 
         """
         self.id_provider = configuration["id_provider"]
-        for field in ["label", "logo", "login_url", "logout_url", "group_mapping"]:
+        for field in [
+            "label",
+            "logo",
+            "login_url",
+            "logout_url",
+            "group_mapping",
+            "is_secondary",
+        ]:
             if field in configuration:
                 setattr(self, field, configuration[field])
 

--- a/src/pypnusershub/routes.py
+++ b/src/pypnusershub/routes.py
@@ -94,6 +94,7 @@ def get_providers():
         "label",
         "login_url",
         "logout_url",
+        "is_secondary",
     ]
     return jsonify(
         [


### PR DESCRIPTION
En lien avec le [ticket 3912 de GeoNature](https://github.com/PnX-SI/GeoNature/issues/3912) de GeoNature.

En lien avec la [PR 3913 de GeoNature](https://github.com/PnX-SI/GeoNature/pull/3913).

- ajout du paramètre `is_secondary` aux fournisseurs d'identité
- doc et orthographe