### PR TITLE
feat: add organisme in get_user_data

### DIFF
--- a/src/pypnusershub/routes.py
+++ b/src/pypnusershub/routes.py
@@ -131,7 +131,7 @@ def get_user_data():
         A dictionary containing the user data, token, and expiration time.
     """
     user_dict_with_token = UserSchema(
-        exclude=["remarques"], only=["+max_level_profil", "+providers"]
+        exclude=["remarques"], only=["+max_level_profil", "+providers", "organisme"]
     ).dump_with_token(g.current_user)
 
     return jsonify(user_dict_with_token)
@@ -167,7 +167,7 @@ def login(provider):
     if isinstance(auth_result, models.User):
         login_user(auth_result, remember=True)
         user_dict_with_token = UserSchema(
-            exclude=["remarques"], only=["+max_level_profil", "+providers"]
+            exclude=["remarques"], only=["+max_level_profil", "+providers", "organisme"]
         ).dump_with_token(auth_result)
         return jsonify(user_dict_with_token)
 
@@ -187,7 +187,7 @@ def public_login():
     login_user(user)
 
     return UserSchema(
-        exclude=["remarques"], only=["+max_level_profil", "+providers"]
+        exclude=["remarques"], only=["+max_level_profil", "+providers", "organisme"]
     ).dump_with_token(user)
 
 


### PR DESCRIPTION
Dans le cadre de l'issue: https://github.com/PnX-SI/GeoNature/issues/4043

PR d'ajout du nom de l'organisme: https://github.com/PnX-SI/GeoNature/pull/4081

Afin de pouvoir afficher le nom de l'organisme associé à l'utilisateur, il faut récupérer le nom de l'organisme. 

Il m'est apparu plus simple de l'intégrer à la route get_user_data, que de rajouter un appel API à simple fin de récuperer le nom de l'organisme.

C'est ce que je propose de faire dans cette PR. 