### PR TITLE
feat: drop md5

### DIFF
--- a/src/pypnusershub/auth/user_manager.py
+++ b/src/pypnusershub/auth/user_manager.py
@@ -79,7 +79,7 @@ class UserManager:
         """
         if not self._check_password_criteria(password):
             raise self.PrintableValueError(
-                "Le mot de passe ne respècte pas les critères"
+                "Le mot de passe ne respecte pas les critères"
             )
 
     def _check_password_criteria(self, password: str) -> bool:

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -128,7 +128,10 @@ class PasswordMixin:
         else:
             raise ValueError(f"User {self.identifiant} has no password")
 
-@serializable(exclude=["_password", "password", "_password_plus", "api_key", "api_secret"])
+
+@serializable(
+    exclude=["_password", "password", "_password_plus", "api_key", "api_secret"]
+)
 class User(db.Model, UserMixin, PasswordMixin):
     __tablename__ = "t_roles"
     __table_args__ = {"schema": "utilisateurs"}

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -23,7 +23,6 @@ if version.parse(flask_sqlalchemy.__version__) >= version.parse("3"):
 else:
     from flask_sqlalchemy import BaseQuery as Query
 
-import logging
 
 from flask import current_app
 from flask_login import UserMixin
@@ -38,9 +37,6 @@ from sqlalchemy.orm.session import object_session
 from sqlalchemy.schema import FetchedValue
 from sqlalchemy.sql import func, select
 from utils_flask_sqla.serializers import serializable
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
 
 
 def check_and_encrypt_password(password, password_confirmation, md5=False):
@@ -121,10 +117,6 @@ class PasswordMixin:
     def check_password(self, pwd):
         if self._password_plus:
             return checkpw(pwd.encode("utf8"), self._password_plus.encode("utf8"))
-        elif self._password:
-            log.warning(
-                f"MD5 password detected for user {self.identifiant}, consider updating it to a stronger hash."
-            )
             are_passwords_equal = (
                 self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
             )

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -11,7 +11,6 @@ mappings applications et utilisateurs
 """
 
 import hashlib
-
 import re
 
 import bcrypt
@@ -23,6 +22,8 @@ if version.parse(flask_sqlalchemy.__version__) >= version.parse("3"):
     from flask_sqlalchemy.query import Query
 else:
     from flask_sqlalchemy import BaseQuery as Query
+
+import logging
 
 from flask import current_app
 from flask_login import UserMixin
@@ -38,6 +39,9 @@ from sqlalchemy.schema import FetchedValue
 from sqlalchemy.sql import func, select
 from utils_flask_sqla.serializers import serializable
 
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
 
 def check_and_encrypt_password(password, password_confirmation, md5=False):
     if not password:
@@ -49,19 +53,6 @@ def check_and_encrypt_password(password, password_confirmation, md5=False):
     if md5:
         pass_md5 = hashlib.md5(password.encode("utf-8")).hexdigest()
     return pass_plus.decode("utf-8"), pass_md5
-
-
-def fn_check_password(self, pwd):
-    if current_app.config["PASS_METHOD"] == "md5":
-        if not self._password:
-            raise ValueError("User %s has no password" % (self.identifiant))
-        return self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
-    elif current_app.config["PASS_METHOD"] == "hash":
-        if not self._password_plus:
-            raise ValueError("User %s has no password" % (self.identifiant))
-        return checkpw(pwd.encode("utf8"), self._password_plus.encode("utf8"))
-    else:
-        raise ValueError("Undefine crypt method (PASS_METHOD)")
 
 
 cor_roles = db.Table(
@@ -126,8 +117,21 @@ class UserQuery(Query):
         )
 
 
+class PasswordMixin:
+    def check_password(self, pwd):
+        if self._password_plus:
+            return checkpw(pwd.encode("utf8"), self._password_plus.encode("utf8"))
+        elif self._password:
+            log.warning(
+                f"MD5 password detected for user {self.identifiant}, consider updating it to a stronger hash."
+            )
+            return self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
+        else:
+            raise ValueError(f"User {self.identifiant} has no password")
+
+
 @serializable(exclude=["_password", "password", "_password_plus"])
-class User(db.Model, UserMixin):
+class User(db.Model, UserMixin, PasswordMixin):
     __tablename__ = "t_roles"
     __table_args__ = {"schema": "utilisateurs"}
     query_class = UserQuery
@@ -200,31 +204,32 @@ class User(db.Model, UserMixin):
 
     @property
     def password(self):
-        if current_app.config["PASS_METHOD"] == "md5":
-            return self._password
-        elif current_app.config["PASS_METHOD"] == "hash":
-            return self._password_plus
-        else:
-            raise Exception
+        return self._password_plus or self._password
 
-    # TODO: change password digest algorithm for something stronger such
-    # as bcrypt. This need to be done at usershub level first.
     @password.setter
-    def password(self, pwd):
-        pwd = pwd.encode("utf-8")
-        if current_app.config["PASS_METHOD"] == "md5":
-            self._password = hashlib.md5(pwd).hexdigest()
-        elif current_app.config["PASS_METHOD"] == "hash":
-            self._password_plus = bcrypt.hashpw(pwd, bcrypt.gensalt()).decode("utf-8")
-        else:
-            raise Exception("Unknown pass method")
+    def password(self, password):
+        """
+        Set the user's password, hashing it with bcrypt (auto-salted) and storing the hash.
+
+        Parameters
+        ----------
+        password : str
+            The plaintext password to set for the user.
+
+        """
+        self._password_plus = bcrypt.hashpw(
+            password.encode("utf-8"), bcrypt.gensalt()
+        ).decode("utf-8")
 
     def generate_api_secret(self):
         """
         Generate a secure random API secret, hash it with bcrypt (auto-salted), and store the hash.
         If Api secret already exists replace it.
 
-        return api key and api secret
+        Returns
+        -------
+        tuple
+            The API key and the raw API secret.
         """
         raw_key = secrets.token_hex(128)
         hashed_key = bcrypt.hashpw(
@@ -237,9 +242,21 @@ class User(db.Model, UserMixin):
         return self.api_key, raw_key
 
     @staticmethod
-    def check_api_key(key, secret):
+    def check_api_key(key: str, secret: str):
         """
         Check if the couple api_key and api_secret match.
+
+        Parameters
+        ----------
+        key : str
+            The API key to check.
+        secret : str
+            The API secret to check.
+
+        Returns
+        -------
+        User or None
+            The user corresponding to the API key and secret if they match, None otherwise.
         """
         statement = select(User).where(User.api_key == key)
         user = db.session.execute(statement).scalars().one()
@@ -248,8 +265,6 @@ class User(db.Model, UserMixin):
         if bcrypt.checkpw(secret.encode(), user.api_secret.encode()):
             return user
         return None
-
-    check_password = fn_check_password
 
     @property
     def is_public(self):
@@ -440,7 +455,7 @@ class UserApplicationRight(db.Model):
 
 
 @serializable(exclude=["password", "_password_plus"])
-class AppUser(db.Model):
+class AppUser(db.Model, PasswordMixin):
     """
     Relations entre applications et utilisateurs
     """
@@ -469,8 +484,6 @@ class AppUser(db.Model):
     @property
     def password(self):
         return self._password
-
-    check_password = fn_check_password
 
     def __repr__(self):
         return "<AppUser role='{}' app='{}'>".format(self.id_role, self.id_application)

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -125,7 +125,12 @@ class PasswordMixin:
             log.warning(
                 f"MD5 password detected for user {self.identifiant}, consider updating it to a stronger hash."
             )
-            return self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
+            are_passwords_equal = (
+                self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
+            )
+            if are_passwords_equal:
+                self.password = pwd  # This will hash the password with bcrypt and update _password_plus
+            return are_passwords_equal
         else:
             raise ValueError(f"User {self.identifiant} has no password")
 

--- a/src/pypnusershub/db/models.py
+++ b/src/pypnusershub/db/models.py
@@ -117,17 +117,18 @@ class PasswordMixin:
     def check_password(self, pwd):
         if self._password_plus:
             return checkpw(pwd.encode("utf8"), self._password_plus.encode("utf8"))
+        elif self._password:
             are_passwords_equal = (
                 self._password == hashlib.md5(pwd.encode("utf8")).hexdigest()
             )
             if are_passwords_equal:
                 self.password = pwd  # This will hash the password with bcrypt and update _password_plus
+                db.session.commit()
             return are_passwords_equal
         else:
             raise ValueError(f"User {self.identifiant} has no password")
 
-
-@serializable(exclude=["_password", "password", "_password_plus"])
+@serializable(exclude=["_password", "password", "_password_plus", "api_key", "api_secret"])
 class User(db.Model, UserMixin, PasswordMixin):
     __tablename__ = "t_roles"
     __table_args__ = {"schema": "utilisateurs"}
@@ -451,7 +452,7 @@ class UserApplicationRight(db.Model):
         )
 
 
-@serializable(exclude=["password", "_password_plus"])
+@serializable(exclude=["password", "_password_plus", "_password"])
 class AppUser(db.Model, PasswordMixin):
     """
     Relations entre applications et utilisateurs

--- a/src/pypnusershub/tests/test_user_management.py
+++ b/src/pypnusershub/tests/test_user_management.py
@@ -141,7 +141,7 @@ class TestCreateTempUser:
         }
         with app.app_context():
             with pytest.raises(
-                ValueError, match="Le mot de passe ne respècte pas les critères"
+                ValueError, match="Le mot de passe ne respecte pas les critères"
             ):
                 user_manager.create_temp_user(data)
 
@@ -246,7 +246,7 @@ class TestChangePassword:
         )  # Enforce strong password rules
         with pytest.raises(
             user_manager.PrintableValueError,
-            match="Le mot de passe ne respècte pas les critères",
+            match="Le mot de passe ne respecte pas les critères",
         ):
             user_manager.change_password("valid_token", "weak", "weak")
 
@@ -402,7 +402,7 @@ class TestRaiseOnPasswordNotMatchingCriterium:
         invalid_password = "password"  # No special characters, uppercase, or digits
         with pytest.raises(
             user_manager.PrintableValueError,
-            match="Le mot de passe ne respècte pas les critères",
+            match="Le mot de passe ne respecte pas les critères",
         ):
             user_manager._raise_on_password_not_matching_criteria(invalid_password)
 


### PR DESCRIPTION
resolves #154 

This PR propose to drop the MD5 password encryption. As a first step, we :
- drop the support of the PASS_METHOD parameter
- when creating/updating a password, we always use Bcrypt
- when checking a password, we use by default the `password_plus` column by default
- When password check is successful using md5, `password_plus` is automatically filled with bcrypt one

In a future release, the `password` column will be dropped. 