### PR TITLE
fix: Do not print api_secret in schema

### DIFF
--- a/src/pypnusershub/schemas.py
+++ b/src/pypnusershub/schemas.py
@@ -32,7 +32,14 @@ class UserSchema(SmartRelationshipsMixin, ma.SQLAlchemyAutoSchema):
         include_fk = True
         load_instance = True
         sqla_session = db.session
-        exclude = ("_password", "_password_plus", "champs_addi", "max_level_profil")
+        exclude = (
+            "_password",
+            "_password_plus",
+            "champs_addi",
+            "max_level_profil",
+            "api_secret",
+            "api_key",
+        )
 
     max_level_profil = fields.Integer()
     nom_complet = fields.String()


### PR DESCRIPTION
This shouldn't be a problem for existing instance as api_key/api_secret is not used but we need to be sure to not print the secret when this will be supported.